### PR TITLE
add build job for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,26 @@
 name: Integration Test Workflow
+
 on: [push, pull_request]
 
 jobs:
-  test:
+  # le premier job est un build. On construit notre image Docker pour tester que le Dockerfile fonctionne
+  build:
+    name: Build Docker Image
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
 
+      - name: Build Docker image
+        # On construit l’image Docker en taguant :test, pour indiquer que c’est une image pour les tests CI
+        run: docker build -t covid-mspr:test -f ../../Dockerfile ../../
+
+  # Le second job lance les tests. Il dépend du job build (il s’exécute que si le build est OK)
+  test:
+    name: Run Tests and Linter
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
       # On stocke les dépendances dans le cache pour éviter de les télécharger à chaque fois. Ça va accélerer
       #le workflow si on n'a pas changé les dépendances.
       - name: Cache pip
@@ -25,7 +38,6 @@ jobs:
 
       - name: Install dependencies
         run: pip install -r requirements.txt
-
       # Un linter qui va nous aider à respecter les conventions de codage mais qui ne va pas bloquer le workflow
       # si on a des erreurs. On améliorera ça tout petit à petit.
       - name: Run flake8 linter (non bloquant)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Build Docker image
         # On construit l’image Docker en taguant :test, pour indiquer que c’est une image pour les tests CI
-        run: docker build -t covid-mspr:test -f ../../Dockerfile ../../
+        run: docker build -t covid-mspr:test -f Dockerfile .
 
   # Le second job lance les tests. Il dépend du job build (il s’exécute que si le build est OK)
   test:


### PR DESCRIPTION
New job when we push. However, we try to run build based on docker image before tests. Tests is launched only if project is successfully build.